### PR TITLE
Limit amount of genres in pie chart

### DIFF
--- a/Localization/LocSource.xaml
+++ b/Localization/LocSource.xaml
@@ -44,6 +44,8 @@
 
     <sys:String x:Key="LOCStatisticsEnableIncludeHiddenGames">Include hidden games</sys:String>
     <sys:String x:Key="LOCStatisticsPreferTopGames">Prefer "Top games" when "All sources"</sys:String>
+    <sys:String x:Key="LOCStatisticsMaxGenres">Max Amount of Genres to display on the Pie Chart</sys:String>
+    <sys:String x:Key="LOCStatisticsMinGenreCount">Mim Amount of games a genre has to have for it to appear on the Pie Chart</sys:String>
 
     <sys:String x:Key="LOCStatisticsIntegration">Interface integration (experimental)</sys:String>
     <sys:String x:Key="LOCStatisticsIntegrationButtonHeader">Add button in window</sys:String>

--- a/Statistics.csproj
+++ b/Statistics.csproj
@@ -297,4 +297,12 @@
     <Content Include="Resources\PluginCommon.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy $(ProjectDir)$(OutDir)*$(TargetExt) M:\Games\Playnite\Extensions\$(TargetName)\ /Y
+xcopy $(ProjectDir)$(OutDir)*.pdb M:\Games\Playnite\Extensions\$(TargetName)\ /Y
+xcopy $(ProjectDir)$(OutDir)extension.yaml M:\Games\Playnite\Extensions\$(TargetName)\ /Y
+xcopy $(ProjectDir)$(OutDir)icon.png M:\Games\Playnite\Extensions\$(TargetName)\ /Y
+mkdir M:\Games\Playnite\Extensions\$(TargetName)\Localization
+xcopy $(ProjectDir)$(OutDir)Localization M:\Games\Playnite\Extensions\$(TargetName)\Localization /Y /D</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Statistics.csproj
+++ b/Statistics.csproj
@@ -297,12 +297,4 @@
     <Content Include="Resources\PluginCommon.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy $(ProjectDir)$(OutDir)*$(TargetExt) M:\Games\Playnite\Extensions\$(TargetName)\ /Y
-xcopy $(ProjectDir)$(OutDir)*.pdb M:\Games\Playnite\Extensions\$(TargetName)\ /Y
-xcopy $(ProjectDir)$(OutDir)extension.yaml M:\Games\Playnite\Extensions\$(TargetName)\ /Y
-xcopy $(ProjectDir)$(OutDir)icon.png M:\Games\Playnite\Extensions\$(TargetName)\ /Y
-mkdir M:\Games\Playnite\Extensions\$(TargetName)\Localization
-xcopy $(ProjectDir)$(OutDir)Localization M:\Games\Playnite\Extensions\$(TargetName)\Localization /Y /D</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/StatisticsSettings.cs
+++ b/StatisticsSettings.cs
@@ -13,7 +13,7 @@ namespace Statistics
         public bool PreferTopGames { get; set; } = true;
 
         public int MaxGenres { get; set; } = 100;
-        public int MinGenreCount { get; set; } = 1;
+        public int MinGenreCount { get; set; } = 2;
 
         public bool EnableIntegrationButtonHeader { get; set; } = false;
 

--- a/StatisticsSettings.cs
+++ b/StatisticsSettings.cs
@@ -12,6 +12,9 @@ namespace Statistics
         public bool IncludeHiddenGames { get; set; } = false;
         public bool PreferTopGames { get; set; } = true;
 
+        public int MaxGenres { get; set; } = 100;
+        public int MinGenreCount { get; set; } = 1;
+
         public bool EnableIntegrationButtonHeader { get; set; } = false;
 
         // Playnite serializes settings object to a JSON object and saves it as text file.
@@ -37,6 +40,9 @@ namespace Statistics
             {
                 IncludeHiddenGames = savedSettings.IncludeHiddenGames;
                 PreferTopGames = savedSettings.PreferTopGames;
+
+                MaxGenres = savedSettings.MaxGenres;
+                MinGenreCount = savedSettings.MinGenreCount;
 
                 EnableIntegrationButtonHeader = savedSettings.EnableIntegrationButtonHeader;
             }

--- a/Views/StatisticsSettingsView.xaml
+++ b/Views/StatisticsSettingsView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" d:DesignHeight="400" d:DesignWidth="600">
     
     <DockPanel Margin="20">
@@ -14,6 +15,50 @@
             <CheckBox IsChecked="{Binding PreferTopGames}" Margin="0,10,0,0">
                 <Label Content="{DynamicResource LOCStatisticsPreferTopGames}"></Label>
             </CheckBox>
+
+            <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
+                <TextBlock Text="{DynamicResource LOCStatisticsMaxGenres}" VerticalAlignment="Center"/>
+                <ComboBox SelectedValue="{Binding MaxGenres}"
+                                                                                                                                  Margin="5,0,0,0">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type system:Int32}">
+                            <system:Int32>10</system:Int32>
+                            <system:Int32>20</system:Int32>
+                            <system:Int32>30</system:Int32>
+                            <system:Int32>50</system:Int32>
+                            <system:Int32>100</system:Int32>
+                            <system:Int32>200</system:Int32>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={StaticResource ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
+                <TextBlock Text="{DynamicResource LOCStatisticsMinGenreCount}" VerticalAlignment="Center"/>
+                <ComboBox SelectedValue="{Binding MinGenreCount}"
+                          Margin="5,0,0,0">
+                    <ComboBox.ItemsSource>
+                        <x:Array Type="{x:Type system:Int32}">
+                            <system:Int32>0</system:Int32>
+                            <system:Int32>1</system:Int32>
+                            <system:Int32>2</system:Int32>
+                            <system:Int32>3</system:Int32>
+                            <system:Int32>5</system:Int32>
+                            <system:Int32>10</system:Int32>
+                        </x:Array>
+                    </ComboBox.ItemsSource>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Converter={StaticResource ObjectToStringConverter}}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
         </StackPanel>
 
         <StackPanel DockPanel.Dock="Bottom" Height="280" Margin="0,20,0,0">

--- a/Views/StatisticsSettingsView.xaml
+++ b/Views/StatisticsSettingsView.xaml
@@ -44,8 +44,6 @@
                           Margin="5,0,0,0">
                     <ComboBox.ItemsSource>
                         <x:Array Type="{x:Type system:Int32}">
-                            <system:Int32>0</system:Int32>
-                            <system:Int32>1</system:Int32>
                             <system:Int32>2</system:Int32>
                             <system:Int32>3</system:Int32>
                             <system:Int32>5</system:Int32>

--- a/Views/StatisticsView.xaml.cs
+++ b/Views/StatisticsView.xaml.cs
@@ -257,7 +257,7 @@ namespace Statistics.Views
 
             //reduce amount of genres
             stats.GameGenres = stats.GameGenres
-                .Where(x => x.Count > _settings.MinGenreCount)
+                .Where(x => x.Count >= _settings.MinGenreCount)
                 .OrderByDescending(x => x.Count)
                 .TakeMax(_settings.MaxGenres).ToList();
 

--- a/Views/StatisticsView.xaml.cs
+++ b/Views/StatisticsView.xaml.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -20,6 +21,15 @@ using System.Windows.Media;
 
 namespace Statistics.Views
 {
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<T> TakeMax<T>(this IEnumerable<T> col, int max)
+        {
+            var count = 0;
+            return col.TakeWhile(x => count++ < max);
+        }
+    }
+
     /// <summary>
     /// Logique d'interaction pour StatisticsView.xaml
     /// </summary>
@@ -27,6 +37,7 @@ namespace Statistics.Views
     {
         private static readonly ILogger logger = LogManager.GetLogger();
         private static StatisticsDatabase StatisticsDatabase = new StatisticsDatabase();
+        private readonly StatisticsSettings _settings;
 
         private ToggleButton _lastToggleButton = null;
         private bool desactiveToogleCheck = false;
@@ -38,6 +49,8 @@ namespace Statistics.Views
             StatisticsDatabase.Initialize(PlayniteApiDatabase, settings);
 
             InitializeComponent();
+
+            _settings = settings;
 
             if (!settings.PreferTopGames)
             {
@@ -242,6 +255,11 @@ namespace Statistics.Views
                 SwitchDataSources.Visibility = Visibility.Hidden;
             }
 
+            //reduce amount of genres
+            stats.GameGenres = stats.GameGenres
+                .Where(x => x.Count > _settings.MinGenreCount)
+                .OrderByDescending(x => x.Count)
+                .TakeMax(_settings.MaxGenres).ToList();
 
             long Total = 0;
             long TotalInstalled = 0;
@@ -318,7 +336,7 @@ namespace Statistics.Views
                     {
                         foreach (var item in StatisticsSourceDatabase)
                         {
-                            temp.Add(new dataTemp() { Name = item.Value.Name, Count = item.Value.Playtime });
+                            temp.Add(new dataTemp { Name = item.Value.Name, Count = item.Value.Playtime });
                         }
                         temp.Sort((a, b) => a.Count.CompareTo(b.Count));
 
@@ -339,7 +357,7 @@ namespace Statistics.Views
                         {
                             foreach (var item in itemAll.Value.GameSource)
                             {
-                                temp.Add(new dataTemp() { Name = item.Name, Count = item.Count });
+                                temp.Add(new dataTemp { Name = item.Name, Count = item.Count });
                             }
                         }
 
@@ -374,7 +392,7 @@ namespace Statistics.Views
                     temp = new List<dataTemp>();
                     foreach (var item in StatisticsSourceDatabase)
                     {
-                        temp.Add(new dataTemp() { Name = item.Name, Count = item.Count });
+                        temp.Add(new dataTemp { Name = item.Name, Count = item.Count });
                     }
 
                     temp.Sort((a, b) => b.Count.CompareTo(a.Count));
@@ -410,7 +428,7 @@ namespace Statistics.Views
                 temp = new List<dataTemp>();
                 foreach (var item in stats.GameGenres)
                 {
-                    temp.Add(new dataTemp() { Name = item.Name, Count = item.Count });
+                    temp.Add(new dataTemp { Name = item.Name, Count = item.Count });
                 }
                 temp.Sort((a, b) => b.Count.CompareTo(a.Count));
 
@@ -423,10 +441,6 @@ namespace Statistics.Views
                         DataLabels = true
                     });
                 }
-            }
-            else
-            {
-
             }
 
 


### PR DESCRIPTION
resolves #13 

Added new settings:
![22-07-2020 17-27-13](https://user-images.githubusercontent.com/16577545/88195697-d6f2ff80-cc2f-11ea-8ddd-bf3542899fce.png)

Pie Chart before:
![21-07-2020 16-42-15 Statistics](https://user-images.githubusercontent.com/16577545/88195724-de1a0d80-cc2f-11ea-8c73-b059e5ee1ddd.png)

(over 500 genres)

![22-07-2020 17-27-54](https://user-images.githubusercontent.com/16577545/88195771-ed00c000-cc2f-11ea-9f74-6d6922ac6801.png)

(limited to 30 and only those who have at least 2 games in it)